### PR TITLE
Align icon image size upper limit message with the eventual error mes…

### DIFF
--- a/ontrack-web/src/app/dialog/dialog.image.tpl.html
+++ b/ontrack-web/src/app/dialog/dialog.image.tpl.html
@@ -10,7 +10,7 @@
         </div>
 
         <p>Select an image. It can be a JPEG, PNG or GIF image. Its size
-        must not exceed 16K.</p>
+        must not exceed 15K.</p>
 
         <p>
             <input type="file" accept=".jpeg,.jpg,.png,.gif" ot-file-model="inputFile" required="required" />


### PR DESCRIPTION
The issue is that the error message is not aligned with the label:

![image (6)](https://user-images.githubusercontent.com/2651620/96474560-3cf12200-1233-11eb-8dfc-fe8fd4d1fe6f.png)
