### PR TITLE
[Claude] #1577: Normalize branch name in Yontrack Promotion notification

### DIFF
--- a/doc/dev-guide/README.md
+++ b/doc/dev-guide/README.md
@@ -8,3 +8,5 @@
 * Components
   * [Model](components/core/README.md) - core model of Ontrack
   * [Properties](components/properties/README.md)
+* Workflows
+  * [Claude Pick Workflow](claude-pick-workflow.md) - Let Claude autonomously pick and implement issues

--- a/doc/dev-guide/claude-pick-workflow.md
+++ b/doc/dev-guide/claude-pick-workflow.md
@@ -1,0 +1,44 @@
+# Claude Pick Workflow
+
+Claude can autonomously pick an open GitHub issue, implement it, and open a draft PR — all from a local Claude Code session.
+
+## Prerequisites
+
+- `gh` CLI authenticated — run `gh auth status` to verify
+- Git push access to `nemerosa/ontrack`
+
+## Labeling issues
+
+Add the `claude-pick` label to any open issue in GitHub to make it eligible.
+Issues that already have an assignee are skipped.
+
+## Triggering
+
+In any Claude Code session at the repo root, say:
+
+> "Pick a claude-pick ticket and implement it"
+
+To target a specific issue:
+
+> "Pick issue #1234 and implement it"
+
+## What Claude does
+
+1. Lists open, unassigned issues labeled `claude-pick` via `gh issue list`
+2. Picks the first candidate — stops and reports if none are found
+3. Comments on the issue: "Picking up this issue, a draft PR will follow"
+4. Creates a branch: `claude/issue-{N}-{short-slug}`
+5. Reads the issue, reads `CLAUDE.md`, explores the relevant codebase
+6. Implements the change following project conventions (backend, frontend, tests, DB migrations as needed)
+7. If the issue is too vague or too large to implement safely, comments explaining why and stops — no partial PR is opened
+8. Commits, pushes the branch, and opens a **draft PR** titled `[Claude] #N: {issue title}`
+
+## Reviewing the result
+
+- The issue will have a WIP comment once Claude picks it up
+- A draft PR will appear in `nemerosa/ontrack` — review the diff and description
+- Nothing is merged without explicit human approval — Claude only creates draft PRs
+
+## Future automation
+
+This workflow runs on demand in a local session. If you want it to run on a schedule or via an API call without an open session, it can be promoted to a [Claude Code Routine](https://claude.ai/code/routines) (requires a Pro/Max/Team/Enterprise plan).

--- a/ontrack-extension-notifications/src/main/java/net/nemerosa/ontrack/extension/notifications/core/YontrackBuildNotificationHelper.kt
+++ b/ontrack-extension-notifications/src/main/java/net/nemerosa/ontrack/extension/notifications/core/YontrackBuildNotificationHelper.kt
@@ -70,7 +70,8 @@ class YontrackBuildNotificationHelper(
             event.getEntity(ProjectEntityType.BRANCH)
         } else {
             val project = getProject(event, projectName)
-            structureService.findBranchByName(project.name, branchName).getOrNull()
+            val normalizedBranchName = NameDescription.escapeName(branchName)
+            structureService.findBranchByName(project.name, normalizedBranchName).getOrNull()
                 ?: throw BranchNotFoundException(project.name, branchName)
         }
 

--- a/ontrack-extension-notifications/src/test/java/net/nemerosa/ontrack/extension/notifications/core/YontrackBuildNotificationHelperTest.kt
+++ b/ontrack-extension-notifications/src/test/java/net/nemerosa/ontrack/extension/notifications/core/YontrackBuildNotificationHelperTest.kt
@@ -1,0 +1,68 @@
+package net.nemerosa.ontrack.extension.notifications.core
+
+import io.mockk.every
+import io.mockk.mockk
+import net.nemerosa.ontrack.model.events.Event
+import net.nemerosa.ontrack.model.exceptions.BranchNotFoundException
+import net.nemerosa.ontrack.model.structure.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class YontrackBuildNotificationHelperTest {
+
+    private lateinit var helper: YontrackBuildNotificationHelper
+    private lateinit var structureService: StructureService
+
+    @BeforeEach
+    fun before() {
+        structureService = mockk()
+        helper = YontrackBuildNotificationHelper(
+            structureService = structureService,
+            buildDisplayNameService = mockk(),
+        )
+    }
+
+    @Test
+    fun `getBranch with already-normalized name finds the branch`() {
+        val project = ProjectFixtures.testProject()
+        val branch = BranchFixtures.testBranch(name = "release-1.0", project = project)
+        val event = mockk<Event>()
+
+        every { structureService.findProjectByName(project.name) } returns Optional.of(project)
+        every { structureService.findBranchByName(project.name, "release-1.0") } returns Optional.of(branch)
+
+        val result = helper.getBranch(event = event, projectName = project.name, branchName = "release-1.0")
+        assertEquals(branch, result)
+    }
+
+    @Test
+    fun `getBranch with SCM-style name normalizes slashes to dashes`() {
+        val project = ProjectFixtures.testProject()
+        val branch = BranchFixtures.testBranch(name = "release-1.0", project = project)
+        val event = mockk<Event>()
+
+        every { structureService.findProjectByName(project.name) } returns Optional.of(project)
+        every { structureService.findBranchByName(project.name, "release-1.0") } returns Optional.of(branch)
+
+        // SCM-style branch name with slash — must be normalized before lookup
+        val result = helper.getBranch(event = event, projectName = project.name, branchName = "release/1.0")
+        assertEquals(branch, result)
+    }
+
+    @Test
+    fun `getBranch throws BranchNotFoundException when normalized name does not exist`() {
+        val project = ProjectFixtures.testProject()
+        val event = mockk<Event>()
+
+        every { structureService.findProjectByName(project.name) } returns Optional.of(project)
+        every { structureService.findBranchByName(project.name, "release-99.0") } returns Optional.empty()
+
+        assertFailsWith<BranchNotFoundException> {
+            helper.getBranch(event = event, projectName = project.name, branchName = "release/99.0")
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes #1577.

When the `branch` field in the Yontrack Promotion notification config contains an SCM-style branch name (e.g. `release/1.0`), the lookup against Ontrack branches was failing because Ontrack stores branch names in normalized form (`release-1.0`).

## Changes

- `YontrackBuildNotificationHelper.getBranch()`: normalize the incoming `branchName` with `NameDescription.escapeName()` before passing it to `findBranchByName`. The original name is preserved in the `BranchNotFoundException` message.
- `YontrackBuildNotificationHelperTest`: new unit tests covering normalized name, SCM-style name (`release/1.0` → `release-1.0`), and missing branch.

## Test plan

- [x] `./gradlew :ontrack-extension-notifications:test --tests "*YontrackBuildNotificationHelperTest*"` — all 3 new tests pass

🤖 Generated with Claude Code